### PR TITLE
Fix empty files returning a 404 status code

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export default {
 				const rawLength = response.headers.get("Content-Length");
 				if (rawLength) {
 					const length = parseInt(rawLength);
-					if (length) {
+					if (!isNaN(length)) {
 						console.info(`${pathname}: Response ${length} bytes`)
 						return new Response(body);
 					} else {


### PR DESCRIPTION
`parseInt` returns NaN if the input string is not a number, which is a falsey value in JS and TS. However, such is 0, which is a valid content length for an empty file:

![image](https://user-images.githubusercontent.com/7822554/190602184-27be2987-44a3-4276-833c-6abbd1346bfe.png)

This PR introduces a explicit check for NaN values so that empty files are properly handled.
